### PR TITLE
Reenable LUT4

### DIFF
--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -188,7 +188,7 @@ struct SynthQuickLogicPass : public ScriptPass
         if (check_label("map_luts")) {
             std::string techMapArgs = " -map +/quicklogic/" + family + "_latches_map.v";
             run("techmap " + techMapArgs);
-            run("abc -luts 1,2,2"); //
+            run("abc -luts 1,2,2,4:8");
 
             techMapArgs = " -map +/quicklogic/" + family + "_ffs_map.v";
             run("techmap " + techMapArgs);


### PR DESCRIPTION
This PR enables back LUT4 inference in ABC.