### PR TITLE
Allow less efficient use of BRAM resources

### DIFF
--- a/techlibs/quicklogic/pp3_brams.txt
+++ b/techlibs/quicklogic/pp3_brams.txt
@@ -37,8 +37,8 @@ endbram
 
 match $__QUICKLOGIC_RAMB16K
 #  attribute ram_style=block ram_block
-  min bits 4096
-  min efficiency 50
+  min bits 128
+  min efficiency 2
 #  shuffle_enable B
   make_transp
   or_next_if_better
@@ -46,8 +46,8 @@ endmatch
 
 match $__QUICKLOGIC_RAMB8K
 #  attribute ram_style=block ram_block
-  min bits 4096
-  min efficiency 50
+  min bits 128
+  min efficiency 2
 #  shuffle_enable B
   make_transp
 endmatch


### PR DESCRIPTION
Before this change, yosys required 4096 bits (or at least 50%)
of the bits in a RAM to be used, in order to implement it as a
PB-RAM. Since there are less than 1000 FFs available in the FPGA
it means that any memory using somewhere between 1k and 4k bits
will not fit in the device.

This lowers the requirements on RAM efficiency to be more in line
with the iCE40 backend, which uses comparably sized FPGAs

Signed-off-by: Olof Kindgren <olof.kindgren@gmail.com>