### PR TITLE
Fix for I/O reg cells.

### DIFF
--- a/techlibs/quicklogic/ap3_cells_sim.v
+++ b/techlibs/quicklogic/ap3_cells_sim.v
@@ -111,7 +111,6 @@ module in_reg (
 	output dataOut,
     (* clkbuf_sink *)
 	input clk, 
-	(* iopad_external_pin *)
 	input rst, 
 	(* iopad_external_pin *)
 	input dataIn
@@ -148,7 +147,6 @@ module out_reg (
 	output dataOut,
     (* clkbuf_sink *)
 	input clk, 
-	(* iopad_external_pin *)
 	input rst, 
 	input dataIn
 );


### PR DESCRIPTION
Removed incorrect `(* iopad_external_pin *)` attributes.