### PR TITLE
Fixes for ap3_wrapcarry

### DIFF
--- a/passes/pmgen/ap3_wrapcarry.cc
+++ b/passes/pmgen/ap3_wrapcarry.cc
@@ -56,6 +56,11 @@ void create_ap3_wrapcarry(ap3_wrapcarry_pm &pm)
 	cell->setPort(ID(I2), I2);
 	cell->setPort(ID(I3), st.lut->getPort(ID(I3)));
 	cell->setPort(ID::O, st.lut->getPort(ID::O));
+
+    if (!st.lut->hasParam(ID(INIT))) {
+        log_error("Cell '%s' of type '%s' has no 'INIT' parameter!\n",
+            st.lut->name.c_str(), st.lut->type.c_str());
+    }
 	cell->setParam(ID::LUT, st.lut->getParam(ID(INIT)));
 
 	for (const auto &a : st.carry->attributes)
@@ -124,9 +129,19 @@ struct AP3WrapCarryPass : public Pass {
 					module->swap_names(carry, cell);
 					auto lut_name = cell->attributes.at(ID(LUT4.name), Const(NEW_ID.str())).decode_string();
 					auto lut = module->addCell(lut_name, ID($lut));
+
 					lut->setParam(ID::WIDTH, 4);
+
+                    if (!cell->hasParam(ID::LUT))
+                        log_error("Cell '%s' of type '%s' has no 'LUT' parameter!\n",
+                            cell->name.c_str(), cell->type.c_str());
 					lut->setParam(ID::LUT, cell->getParam(ID::LUT));
+
+                    if (!cell->hasParam(ID(I2_IS_CI)))
+                        log_error("Cell '%s' of type '%s' has no 'I2_IS_CI' parameter!\n",
+                            cell->name.c_str(), cell->type.c_str());
 					auto I2 = cell->getPort(cell->getParam(ID(I2_IS_CI)).as_bool() ? ID::CI : ID(I2));
+
 					lut->setPort(ID::A, {cell->getPort(ID(I3)), I2, cell->getPort(ID::B), cell->getPort(ID::A)});
 					lut->setPort(ID::Y, cell->getPort(ID::O));
 

--- a/passes/pmgen/ap3_wrapcarry.cc
+++ b/passes/pmgen/ap3_wrapcarry.cc
@@ -124,7 +124,8 @@ struct AP3WrapCarryPass : public Pass {
                     auto carry = module->addCell(NEW_ID, ID(QL_CARRY));
                     carry->setPort(ID(I0), cell->getPort(ID::A));
                     carry->setPort(ID(I1), cell->getPort(ID::B));
-                    carry->setPort(ID::CI, cell->getPort(ID::CI));
+                    auto CI = cell->getPort(ID::CI);
+                    carry->setPort(ID::CI, (CI.empty()) ? RTLIL::Const(RTLIL::State::Sx) : CI);
                     carry->setPort(ID::CO, cell->getPort(ID::CO));
                     module->swap_names(carry, cell);
                     auto lut_name = cell->attributes.at(ID(LUT4.name), Const(NEW_ID.str())).decode_string();
@@ -150,7 +151,7 @@ struct AP3WrapCarryPass : public Pass {
                         cell->getPort(ID(I3))
                     };
 
-                    RTLIL::SigSpec signal(RTLIL::State::Sz, 4);
+                    RTLIL::SigSpec signal(RTLIL::State::Sx, 4);
                     for (size_t i=0; i<4; ++i) {
                         if (!parts[i].empty()) {
 

--- a/passes/pmgen/ap3_wrapcarry.cc
+++ b/passes/pmgen/ap3_wrapcarry.cc
@@ -27,120 +27,120 @@ PRIVATE_NAMESPACE_BEGIN
 
 void create_ap3_wrapcarry(ap3_wrapcarry_pm &pm)
 {
-	auto &st = pm.st_ap3_wrapcarry;
+    auto &st = pm.st_ap3_wrapcarry;
 
 #if 0
-	log("\n");
-	log("carry: %s\n", log_id(st.carry, "--"));
-	log("lut:   %s\n", log_id(st.lut, "--"));
+    log("\n");
+    log("carry: %s\n", log_id(st.carry, "--"));
+    log("lut:   %s\n", log_id(st.lut, "--"));
 #endif
 
-	log("  replacing LUT4 + QL_CARRY with $__AP3_CARRY_WRAPPER cell.\n");
+    log("  replacing LUT4 + QL_CARRY with $__AP3_CARRY_WRAPPER cell.\n");
 
-	Cell *cell = pm.module->addCell(NEW_ID, ID($__AP3_CARRY_WRAPPER));
-	pm.module->swap_names(cell, st.carry);
+    Cell *cell = pm.module->addCell(NEW_ID, ID($__AP3_CARRY_WRAPPER));
+    pm.module->swap_names(cell, st.carry);
 
-	cell->setPort(ID::A, st.carry->getPort(ID(I0)));
-	cell->setPort(ID::B, st.carry->getPort(ID(I1)));
-	auto CI = st.carry->getPort(ID::CI);
-	cell->setPort(ID::CI, CI);
-	cell->setPort(ID::CO, st.carry->getPort(ID::CO));
+    cell->setPort(ID::A, st.carry->getPort(ID(I0)));
+    cell->setPort(ID::B, st.carry->getPort(ID(I1)));
+    auto CI = st.carry->getPort(ID::CI);
+    cell->setPort(ID::CI, CI);
+    cell->setPort(ID::CO, st.carry->getPort(ID::CO));
 
-	auto I2 = st.lut->getPort(ID(I2));
-	if (pm.sigmap(CI) == pm.sigmap(I2)) {
-		cell->setParam(ID(I2_IS_CI), State::S1);
-		I2 = State::Sx;
-	}
-	else
-		cell->setParam(ID(I2_IS_CI), State::S0);
-	cell->setPort(ID(I2), I2);
-	cell->setPort(ID(I3), st.lut->getPort(ID(I3)));
-	cell->setPort(ID::O, st.lut->getPort(ID::O));
+    auto I2 = st.lut->getPort(ID(I2));
+    if (pm.sigmap(CI) == pm.sigmap(I2)) {
+        cell->setParam(ID(I2_IS_CI), State::S1);
+        I2 = State::Sx;
+    }
+    else
+        cell->setParam(ID(I2_IS_CI), State::S0);
+    cell->setPort(ID(I2), I2);
+    cell->setPort(ID(I3), st.lut->getPort(ID(I3)));
+    cell->setPort(ID::O, st.lut->getPort(ID::O));
 
     if (!st.lut->hasParam(ID(INIT))) {
         log_error("Cell '%s' of type '%s' has no 'INIT' parameter!\n",
             st.lut->name.c_str(), st.lut->type.c_str());
     }
-	cell->setParam(ID::LUT, st.lut->getParam(ID(INIT)));
+    cell->setParam(ID::LUT, st.lut->getParam(ID(INIT)));
 
-	for (const auto &a : st.carry->attributes)
-		cell->attributes[stringf("\\QL_CARRY.%s", a.first.c_str())] = a.second;
-	for (const auto &a : st.lut->attributes)
-		cell->attributes[stringf("\\LUT4.%s", a.first.c_str())] = a.second;
-	cell->attributes[ID(LUT4.name)] = Const(st.lut->name.str());
-	if (st.carry->get_bool_attribute(ID::keep) || st.lut->get_bool_attribute(ID::keep))
-		cell->attributes[ID::keep] = true;
+    for (const auto &a : st.carry->attributes)
+        cell->attributes[stringf("\\QL_CARRY.%s", a.first.c_str())] = a.second;
+    for (const auto &a : st.lut->attributes)
+        cell->attributes[stringf("\\LUT4.%s", a.first.c_str())] = a.second;
+    cell->attributes[ID(LUT4.name)] = Const(st.lut->name.str());
+    if (st.carry->get_bool_attribute(ID::keep) || st.lut->get_bool_attribute(ID::keep))
+        cell->attributes[ID::keep] = true;
 
-	pm.autoremove(st.carry);
-	pm.autoremove(st.lut);
+    pm.autoremove(st.carry);
+    pm.autoremove(st.lut);
 }
 
 struct AP3WrapCarryPass : public Pass {
-	AP3WrapCarryPass() : Pass("ap3_wrapcarry", "AP3: wrap carries") { }
-	void help() YS_OVERRIDE
-	{
-		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
-		log("\n");
-		log("    ap3_wrapcarry [selection]\n");
-		log("\n");
-		log("Wrap manually instantiated QL_CARRY cells, along with their associated LUT4s,\n");
-		log("into an internal $__AP3_CARRY_WRAPPER cell for preservation across technology\n");
-		log("mapping.\n");
-		log("\n");
-		log("Attributes on both cells will have their names prefixed with 'QL_CARRY.' or\n");
-		log("'LUT4.' and attached to the wrapping cell.\n");
-		log("A (* keep *) attribute on either cell will be logically OR-ed together.\n");
-		log("\n");
-		log("    -unwrap\n");
-		log("        unwrap $__AP3_CARRY_WRAPPER cells back into QL_CARRYs and LUT4s,\n");
-		log("        including restoring their attributes.\n");
-		log("\n");
-	}
-	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
-	{
-		bool unwrap = false;
+    AP3WrapCarryPass() : Pass("ap3_wrapcarry", "AP3: wrap carries") { }
+    void help() YS_OVERRIDE
+    {
+        //   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+        log("\n");
+        log("    ap3_wrapcarry [selection]\n");
+        log("\n");
+        log("Wrap manually instantiated QL_CARRY cells, along with their associated LUT4s,\n");
+        log("into an internal $__AP3_CARRY_WRAPPER cell for preservation across technology\n");
+        log("mapping.\n");
+        log("\n");
+        log("Attributes on both cells will have their names prefixed with 'QL_CARRY.' or\n");
+        log("'LUT4.' and attached to the wrapping cell.\n");
+        log("A (* keep *) attribute on either cell will be logically OR-ed together.\n");
+        log("\n");
+        log("    -unwrap\n");
+        log("        unwrap $__AP3_CARRY_WRAPPER cells back into QL_CARRYs and LUT4s,\n");
+        log("        including restoring their attributes.\n");
+        log("\n");
+    }
+    void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+    {
+        bool unwrap = false;
 
-		log_header(design, "Executing ap3_wrapcarry pass (wrap carries).\n");
+        log_header(design, "Executing ap3_wrapcarry pass (wrap carries).\n");
 
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			if (args[argidx] == "-unwrap") {
-				unwrap = true;
-				continue;
-			}
-			break;
-		}
-		extra_args(args, argidx, design);
+        size_t argidx;
+        for (argidx = 1; argidx < args.size(); argidx++)
+        {
+            if (args[argidx] == "-unwrap") {
+                unwrap = true;
+                continue;
+            }
+            break;
+        }
+        extra_args(args, argidx, design);
 
-		for (auto module : design->selected_modules()) {
-			if (!unwrap) {
-				ap3_wrapcarry_pm(module, module->selected_cells()).run_ap3_wrapcarry(create_ap3_wrapcarry);
-			} else {
-				for (auto cell : module->selected_cells()) {
-					if (cell->type != ID($__AP3_CARRY_WRAPPER))
-						continue;
+        for (auto module : design->selected_modules()) {
+            if (!unwrap) {
+                ap3_wrapcarry_pm(module, module->selected_cells()).run_ap3_wrapcarry(create_ap3_wrapcarry);
+            } else {
+                for (auto cell : module->selected_cells()) {
+                    if (cell->type != ID($__AP3_CARRY_WRAPPER))
+                        continue;
 
-					auto carry = module->addCell(NEW_ID, ID(QL_CARRY));
-					carry->setPort(ID(I0), cell->getPort(ID::A));
-					carry->setPort(ID(I1), cell->getPort(ID::B));
-					carry->setPort(ID::CI, cell->getPort(ID::CI));
-					carry->setPort(ID::CO, cell->getPort(ID::CO));
-					module->swap_names(carry, cell);
-					auto lut_name = cell->attributes.at(ID(LUT4.name), Const(NEW_ID.str())).decode_string();
-					auto lut = module->addCell(lut_name, ID($lut));
+                    auto carry = module->addCell(NEW_ID, ID(QL_CARRY));
+                    carry->setPort(ID(I0), cell->getPort(ID::A));
+                    carry->setPort(ID(I1), cell->getPort(ID::B));
+                    carry->setPort(ID::CI, cell->getPort(ID::CI));
+                    carry->setPort(ID::CO, cell->getPort(ID::CO));
+                    module->swap_names(carry, cell);
+                    auto lut_name = cell->attributes.at(ID(LUT4.name), Const(NEW_ID.str())).decode_string();
+                    auto lut = module->addCell(lut_name, ID($lut));
 
-					lut->setParam(ID::WIDTH, 4);
+                    lut->setParam(ID::WIDTH, 4);
 
                     if (!cell->hasParam(ID::LUT))
                         log_error("Cell '%s' of type '%s' has no 'LUT' parameter!\n",
                             cell->name.c_str(), cell->type.c_str());
-					lut->setParam(ID::LUT, cell->getParam(ID::LUT));
+                    lut->setParam(ID::LUT, cell->getParam(ID::LUT));
 
                     if (!cell->hasParam(ID(I2_IS_CI)))
                         log_error("Cell '%s' of type '%s' has no 'I2_IS_CI' parameter!\n",
                             cell->name.c_str(), cell->type.c_str());
-					auto I2 = cell->getPort(cell->getParam(ID(I2_IS_CI)).as_bool() ? ID::CI : ID(I2));
+                    auto I2 = cell->getPort(cell->getParam(ID(I2_IS_CI)).as_bool() ? ID::CI : ID(I2));
 
                     // Build new connection to the $lut.A port
                     std::vector<RTLIL::SigSpec> parts = {
@@ -165,31 +165,31 @@ struct AP3WrapCarryPass : public Pass {
                     }
 
                     lut->setPort(ID::A, signal);
-					lut->setPort(ID::Y, cell->getPort(ID::O));
+                    lut->setPort(ID::Y, cell->getPort(ID::O));
 
-					Const src;
-					for (const auto &a : cell->attributes)
-						if (a.first.begins_with("\\QL_CARRY.\\"))
-							carry->attributes[a.first.c_str() + strlen("\\QL_CARRY.")] = a.second;
-						else if (a.first.begins_with("\\LUT4.\\"))
-							lut->attributes[a.first.c_str() + strlen("\\LUT4.")] = a.second;
-						else if (a.first == ID::src)
-							src = a.second;
-						else if (a.first.in(ID(LUT4.name), ID::keep, ID::module_not_derived))
-							continue;
-						else
-							log_abort();
+                    Const src;
+                    for (const auto &a : cell->attributes)
+                        if (a.first.begins_with("\\QL_CARRY.\\"))
+                            carry->attributes[a.first.c_str() + strlen("\\QL_CARRY.")] = a.second;
+                        else if (a.first.begins_with("\\LUT4.\\"))
+                            lut->attributes[a.first.c_str() + strlen("\\LUT4.")] = a.second;
+                        else if (a.first == ID::src)
+                            src = a.second;
+                        else if (a.first.in(ID(LUT4.name), ID::keep, ID::module_not_derived))
+                            continue;
+                        else
+                            log_abort();
 
-					if (!src.empty()) {
-						carry->attributes.insert(std::make_pair(ID::src, src));
-						lut->attributes.insert(std::make_pair(ID::src, src));
-					}
+                    if (!src.empty()) {
+                        carry->attributes.insert(std::make_pair(ID::src, src));
+                        lut->attributes.insert(std::make_pair(ID::src, src));
+                    }
 
-					module->remove(cell);
-				}
-			}
-		}
-	}
+                    module->remove(cell);
+                }
+            }
+        }
+    }
 } AP3WrapCarryPass;
 
 PRIVATE_NAMESPACE_END

--- a/techlibs/quicklogic/ap3_arith_map.v
+++ b/techlibs/quicklogic/ap3_arith_map.v
@@ -32,10 +32,7 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
     (* force_downto *)
     wire [Y_WIDTH-1:0] BB = BI ? ~B_buf : B_buf;
     (* force_downto *)
-    wire [Y_WIDTH-1:0] C = {CO, CI};
-
-    wire ci;
-    wire co;
+    wire [Y_WIDTH-1:0] C;
 
 //     genvar i;
 //    generate for (i = 0; i < Y_WIDTH; i = i + 1) begin: slice
@@ -55,13 +52,16 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 //    end: slice
 //    endgenerate
 
+    assign CO = C[Y_WIDTH-1];
+
     genvar i;
     generate for (i = 0; i < Y_WIDTH; i = i + 1) begin: slice
+
+        wire ci;
+        wire co;
+
         // First in chain
         generate if (i == 0) begin
-            // Carry-chain init stub
-            wire c0;
-            CI_STUB stub (.C0(c0));
 
             // CI connected to a constant
             if (_TECHMAP_CONSTMSK_CI_ == 1) begin
@@ -73,14 +73,14 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
                 // LUT4 configured as 1-bit adder with CI=const
                 \$__AP3_CARRY_WRAPPER #(
                     .LUT(INIT),
-                    .I2_IS_CI(1'b1)
+                    .I2_IS_CI(1'b0)
                 ) lut_ci_adder (
                     .A(AA[i]),
                     .B(BB[i]),
                     .I2(),
                     .I3(1'b0),
                     .O(Y[i]),
-                    .CI(c0),
+                    .CI(),
                     .CO(ci)
                 );
 
@@ -90,21 +90,21 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
                 // LUT4 configured as passthrough to drive CI of the next stage
                 \$__AP3_CARRY_WRAPPER #(
                     .LUT(16'b11000000_00001100),
-                    .I2_IS_CI(1'b1)
+                    .I2_IS_CI(1'b0)
                 ) lut_ci (
                     .A(),
-                    .B(CI[i]),
+                    .B(CI),
                     .I2(),
                     .I3(),
                     .O(),
-                    .CI(c0),
+                    .CI(),
                     .CO(ci)
                 );
             end
 
         // Not first in chain
         end else begin
-            assign ci = C[i];
+            assign ci = C[i-1];
 
         end endgenerate
 
@@ -112,14 +112,13 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 
         // Single 1-bit adder, mid-chain adder or non-const CI
         // adder
-        generate if ((Y_WIDTH == 1) ||
-                     (i == 0 && _TECHMAP_CONSTMSK_CI_ == 0) ||
-                     (i > 0 && i < Y_WIDTH-1)) begin
+        generate if ((i == 0 && _TECHMAP_CONSTMSK_CI_ == 0) ||
+                     (i  > 0 && i < Y_WIDTH-1)) begin
             
             // LUT4 configured as full 1-bit adder
             \$__AP3_CARRY_WRAPPER #(
                     .LUT(16'b10000110_10010110),
-                    .I2_IS_CI(1'b0)
+                    .I2_IS_CI(1'b1)
                 ) lut_adder (
                     .A(AA[i]),
                     .B(BB[i]),
@@ -143,19 +142,19 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
             // get pruned if the actual CO port is not connected anywhere.
             \$__AP3_CARRY_WRAPPER #(
                     .LUT(16'b11110000_11110000),
-                    .I2_IS_CI(1'b0)
+                    .I2_IS_CI(1'b1)
                 ) lut_co (
                     .A(),
                     .B(),
                     .I2(),
                     .I3(),
-                    .O(CO[i]),
+                    .O(C[i]),
                     .CI(co),
                     .CO()
                 );
         // Not last in chain
         end else begin
-            assign CO[i] = co;
+            assign C[i] = co;
 
         end endgenerate
 

--- a/techlibs/quicklogic/ap3_arith_map.v
+++ b/techlibs/quicklogic/ap3_arith_map.v
@@ -37,25 +37,25 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
     wire ci;
     wire co;
 
-     genvar i;
-    generate for (i = 0; i < Y_WIDTH; i = i + 1) begin: slice
-        \$__AP3_CARRY_WRAPPER #(
-            .LUT(16'b 1110_1000_1001_0110),
-            .I2_IS_CI(1'b1)
-        ) carry (
-			.A(AA[i]),
-			.B(BB[i]),
-			.CI(C[i]),
-			.I2(1'bx),
-			.I3(1'b0),
-			.CO(CO[i]),
-			.O(Y[i])
-		);
+//     genvar i;
+//    generate for (i = 0; i < Y_WIDTH; i = i + 1) begin: slice
+//        \$__AP3_CARRY_WRAPPER #(
+//            .LUT(16'b 1110_1000_1001_0110),
+//            .I2_IS_CI(1'b1)
+//        ) carry (
+//			.A(AA[i]),
+//			.B(BB[i]),
+//			.CI(C[i]),
+//			.I2(1'bx),
+//			.I3(1'b0),
+//			.CO(CO[i]),
+//			.O(Y[i])
+//		);
+//
+//    end: slice
+//    endgenerate
 
-    end: slice	  
-    endgenerate
-
-    /*genvar i;
+    genvar i;
     generate for (i = 0; i < Y_WIDTH; i = i + 1) begin: slice
         // First in chain
         generate if (i == 0) begin
@@ -72,7 +72,7 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 
                 // LUT4 configured as 1-bit adder with CI=const
                 \$__AP3_CARRY_WRAPPER #(
-                    .INIT(INIT),
+                    .LUT(INIT),
                     .I2_IS_CI(1'b1)
                 ) lut_ci_adder (
                     .A(AA[i]),
@@ -89,7 +89,7 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 
                 // LUT4 configured as passthrough to drive CI of the next stage
                 \$__AP3_CARRY_WRAPPER #(
-                    .INIT(16'b11000000_00001100),
+                    .LUT(16'b11000000_00001100),
                     .I2_IS_CI(1'b1)
                 ) lut_ci (
                     .A(),
@@ -118,7 +118,7 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
             
             // LUT4 configured as full 1-bit adder
             \$__AP3_CARRY_WRAPPER #(
-                    .INIT(16'b10000110_10010110),
+                    .LUT(16'b10000110_10010110),
                     .I2_IS_CI(1'b0)
                 ) lut_adder (
                     .A(AA[i]),
@@ -142,7 +142,7 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
             // LUT4 configured for passing its CI input to output. This should
             // get pruned if the actual CO port is not connected anywhere.
             \$__AP3_CARRY_WRAPPER #(
-                    .INIT(16'b11110000_11110000),
+                    .LUT(16'b11110000_11110000),
                     .I2_IS_CI(1'b0)
                 ) lut_co (
                     .A(),
@@ -161,8 +161,6 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 
     end: slice	  
     endgenerate
-    */
-    
 
     /* End implementation */
     assign X = AA ^ BB;

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -162,6 +162,7 @@ struct SynthQuickLogicPass : public ScriptPass {
         if (check_label("begin")) {
             std::string readVelArgs = " +/quicklogic/" + family + "_cells_sim.v";
             run("read_verilog -lib -specify +/quicklogic/cells_sim.v" + readVelArgs);
+	        run("read_verilog -lib -specify +/quicklogic/abc9_model.v");
             run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
         }
 


### PR DESCRIPTION
I've managed to fix all the issues:
 - The techmap was setting the `INIT` parameter while the `ap3_wrapcarry` pass was refering to the `LUT` parameter.
 - Connections to "unwrapped" LUT were created incorrectly when some ports were unconnected. I've fixed that by enforcing `X` on all unconnected ports.
 - The techmap that inserted `$__AP3_CARRY_WRAPPER` was incorrect. I've fixed it.