### PR TITLE
Soft adder fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -783,6 +783,7 @@ test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/arch/anlogic && bash run-test.sh $(SEEDOPT)
 	+cd tests/arch/gowin && bash run-test.sh $(SEEDOPT)
 	+cd tests/arch/intel_alm && bash run-test.sh $(SEEDOPT)
+	+cd tests/arch/quicklogic && bash run-test.sh $(SEEDOPT)
 	+cd tests/rpc && bash run-test.sh
 	+cd tests/memfile && bash run-test.sh
 	+cd tests/verilog && bash run-test.sh

--- a/techlibs/quicklogic/abc9_softadder_model.v
+++ b/techlibs/quicklogic/abc9_softadder_model.v
@@ -1,29 +1,32 @@
 (* abc9_box, lib_whitebox *)
 module soft_adder (
-	(* abc9_carry *)
-	output CO,
-	output O,
-	input A, B,
-	(* abc9_carry *)
-	input CI,
-	input I2, I3
+    (* abc9_carry *)
+    output CO,
+    output O,
+    input A, B,
+    (* abc9_carry *)
+    input CI,
+    input I2, I3
 );
-	parameter LUT = 0;
-	parameter I2_IS_CI = 0;
-	wire I2_OR_CI = I2_IS_CI ? CI : I2;
-	carry_follower carry (
-		.A(A),
-		.B(B),
-		.CI(CI),
-		.CO(CO)
-	);
-	LUT4 #(
-		.INIT(LUT)
-	) adder (
-		.I0(A),
-		.I1(B),
-		.I2(I2_OR_CI),
-		.I3(I3),
-		.O(O)
-	);
+    parameter LUT = 0;
+    parameter I2_IS_CI = 0;
+
+    // Effective LUT input
+    wire [3:0] li = (I2_IS_CI) ? {I3, CI, B, A} : {I3, I2, B, A};
+
+    // Output function
+    wire [7:0] s1 = li[0] ?
+        {LUT[15], LUT[13], LUT[11], LUT[9], LUT[7], LUT[5], LUT[3], LUT[1]} :
+        {LUT[14], LUT[12], LUT[10], LUT[8], LUT[6], LUT[4], LUT[2], LUT[0]};
+
+    wire [3:0] s2 = li[1] ? {s1[7], s1[5], s1[3], s1[1]} :
+                            {s1[6], s1[4], s1[2], s1[0]};
+
+    wire [1:0] s3 = li[2] ? {s2[3], s2[1]} : {s2[2], s2[0]};
+
+    assign      O = li[3] ? s3[1] : s3[0];
+
+    // Carry out function
+    assign CO = (s2[2]) ? CI : s2[3];
+
 endmodule

--- a/techlibs/quicklogic/openfpga_arith_map.v
+++ b/techlibs/quicklogic/openfpga_arith_map.v
@@ -49,8 +49,8 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
             if (_TECHMAP_CONSTMSK_CI_ == 1) begin
 
                 localparam INIT = (_TECHMAP_CONSTVAL_CI_ == 0) ?
-                    16'b11100110_01100110 :
-                    16'b11111000_10011001;
+                    16'b10000000_00000110 :
+                    16'b11100000_00001001;
 
                 // LUT4 configured as 1-bit adder with CI=const
                 soft_adder #(
@@ -59,7 +59,7 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
                 ) lut_ci_adder (
                     .A(AA[i]),
                     .B(BB[i]),
-                    .I2(),
+                    .I2(1'b0),
                     .I3(1'b0),
                     .O(Y[i]),
                     .CI(),
@@ -94,8 +94,7 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 
         // Single 1-bit adder, mid-chain adder or non-const CI
         // adder
-        generate if ((i == 0 && _TECHMAP_CONSTMSK_CI_ == 0) ||
-                     (i  > 0 && i < Y_WIDTH-1)) begin
+        generate if ((i == 0 && _TECHMAP_CONSTMSK_CI_ == 0) || (i > 0)) begin
             
             // LUT4 configured as full 1-bit adder
             soft_adder #(

--- a/tests/arch/quicklogic/dffs.ys
+++ b/tests/arch/quicklogic/dffs.ys
@@ -4,7 +4,7 @@ design -save read
 # DFF
 hierarchy -top my_dff
 proc
-equiv_opt -assert -map +/quicklogic/cells_sim.v synth_quicklogic -top my_dff -flatten
+equiv_opt -assert -map +/quicklogic/pp3_cells_sim.v synth_quicklogic -top my_dff
 design -load postopt
 cd my_dff
 stat
@@ -16,7 +16,7 @@ select -assert-count 4 t:*
 
 # DFFC
 design -load read
-synth_quicklogic -top my_dffc -flatten
+synth_quicklogic -top my_dffc
 cd my_dffc
 stat
 select -assert-count 1 t:dffc
@@ -27,7 +27,7 @@ select -assert-count 5 t:*
 
 # DFFP
 design -load read
-synth_quicklogic -top my_dffp -flatten
+synth_quicklogic -top my_dffp
 cd my_dffp
 stat
 select -assert-count 1 t:dffp

--- a/tests/arch/quicklogic/latches.ys
+++ b/tests/arch/quicklogic/latches.ys
@@ -2,7 +2,7 @@ read_verilog v/latches.v
 design -save read
 
 # LATCHP
-synth_quicklogic -flatten -top latchp
+synth_quicklogic -top latchp
 cd latchp
 stat
 select -assert-count 1 t:LUT3
@@ -12,12 +12,11 @@ select -assert-count 5 t:*
 
 # LATCHN
 design -load read
-synth_quicklogic -flatten -top latchn
+synth_quicklogic -top latchn
 cd latchn
 stat
-select -assert-count 1 t:LUT1
 select -assert-count 1 t:LUT3
 select -assert-count 3 t:inpad
 select -assert-count 1 t:outpad
-select -assert-count 6 t:*
+select -assert-count 5 t:*
 

--- a/tests/arch/quicklogic/logic.ys
+++ b/tests/arch/quicklogic/logic.ys
@@ -1,7 +1,7 @@
 read_verilog v/logic.v
 hierarchy -top top
 proc
-equiv_opt -assert -map +/quicklogic/cells_sim.v synth_quicklogic -flatten
+equiv_opt -assert -map +/quicklogic/pp3_cells_sim.v synth_quicklogic
 design -load postopt
 cd top
 

--- a/tests/arch/quicklogic/soft_adder.ys
+++ b/tests/arch/quicklogic/soft_adder.ys
@@ -1,0 +1,13 @@
+# Equivalence check for adder synthesis
+read_verilog -icells -DWIDTH=4 v/add.v
+hierarchy -check -auto-top
+proc
+equiv_opt -assert -map +/quicklogic/abc9_softadder_model.v synth_quicklogic -openfpga -adder
+
+design -reset
+
+# Equivalence check for subtractor synthesis
+read_verilog -icells -DWIDTH=4 v/sub.v
+hierarchy -check -auto-top
+proc
+equiv_opt -assert -map +/quicklogic/abc9_softadder_model.v synth_quicklogic -openfpga -adder

--- a/tests/arch/quicklogic/v/add.v
+++ b/tests/arch/quicklogic/v/add.v
@@ -1,0 +1,10 @@
+module adder (
+    input  wire [`WIDTH-1:0] A,
+    input  wire [`WIDTH-1:0] B,
+    output wire [`WIDTH  :0] S,
+);
+
+    // Implicit adder
+    assign S = A + B;
+
+endmodule

--- a/tests/arch/quicklogic/v/consts.v
+++ b/tests/arch/quicklogic/v/consts.v
@@ -1,3 +1,4 @@
+(* keep_hierarchy *)
 module my_lut (
     input  wire [3:0] i,
     output wire       o

--- a/tests/arch/quicklogic/v/sub.v
+++ b/tests/arch/quicklogic/v/sub.v
@@ -1,0 +1,10 @@
+module subtractor (
+    input  wire [`WIDTH-1:0] A,
+    input  wire [`WIDTH-1:0] B,
+    output wire [`WIDTH  :0] S,
+);
+
+    // Implicit subtractor
+    assign S = A - B;
+
+endmodule


### PR DESCRIPTION
This PR fixed both techmap and simulation model for `soft_adder`. It also adds a test which verifies pre and post synthesis equivalence of adders.

The QuickLogic arch tests are fixed and enabled so that they are run by CI.