### PR TITLE
Soft adder techmap fixes

### DIFF
--- a/techlibs/quicklogic/openfpga_arith_map.v
+++ b/techlibs/quicklogic/openfpga_arith_map.v
@@ -42,7 +42,9 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
         wire ci;
         wire co;
 
-        wire [0:1] lut2_out;
+        wire [0:1] lut2_out_1;
+        wire [0:1] lut2_out_2;
+        wire [0:1] lut2_out_3;
 
         // First in chain
         generate if (i == 0) begin
@@ -59,13 +61,13 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
                     .LUT(INIT)
                 ) lut_inst_1 (
                     .in({AA[i], BB[i], 1'b0, 1'b0}),
-                    .lut2_out(lut2_out),
+                    .lut2_out(lut2_out_1),
                     .lut4_out(Y[i])
                 );
                 carry_follower carry_inst_1(
-                    .a(lut2_out[1]),
+                    .a(lut2_out_1[1]),
                     .b(),
-                    .cin(lut2_out[0]),
+                    .cin(lut2_out_1[0]),
                     .cout(ci)
                 );
 
@@ -76,14 +78,14 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
                 frac_lut4 #(
                     .LUT(16'b1100_0000_0000_0011)
                 ) lut_inst_2 (
-                    .in({1'bx, CI, 1'bx, 1'bx}),
-                    .lut2_out(lut2_out),
+                    .in({1'b0, CI, 1'b0, 1'b0}),
+                    .lut2_out(lut2_out_1),
                     .lut4_out()
                 );
                 carry_follower carry_inst_2(
-                    .a(lut2_out[1]),
+                    .a(lut2_out_1[1]),
                     .b(),
-                    .cin(lut2_out[0]),
+                    .cin(lut2_out_1[0]),
                     .cout(ci)
                 );
             end
@@ -105,13 +107,13 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
                 .LUT(16'b0110_1001_0110_0001)
             ) lut_inst_3 (
                 .in({AA[i], BB[i], ci, 1'b0}),
-                .lut2_out(lut2_out),
+                .lut2_out(lut2_out_2),
                 .lut4_out(Y[i])
             );
             carry_follower carry_inst_3(
-                .a(lut2_out[1]),
+                .a(lut2_out_2[1]),
                 .b(ci),
-                .cin(lut2_out[0]),
+                .cin(lut2_out_2[0]),
                 .cout(co)
             );
                          
@@ -124,19 +126,20 @@ module _80_quicklogic_alu (A, B, CI, BI, X, Y, CO);
 
         // Last in chain
         generate if (i == Y_WIDTH-1) begin
+
             // LUT4 configured for passing its CI input to output. This should
             // get pruned if the actual CO port is not connected anywhere.
             frac_lut4 #(
                 .LUT(16'b0000_1111_0000_1111)
             ) lut_inst_4 (
-                .in({1'bx, co, 1'bx, 1'bx}),
-                .lut2_out(lut2_out),
+                .in({1'b0, co, 1'b0, 1'b0}),
+                .lut2_out(lut2_out_3),
                 .lut4_out(C[i])
             );
             carry_follower carry_inst_4(
-                .a(lut2_out[1]),
+                .a(lut2_out_3[1]),
                 .b(co),
-                .cin(lut2_out[0]),
+                .cin(lut2_out_3[0]),
                 .cout()
             );
         // Not last in chain


### PR DESCRIPTION
This PR fixes some issues with the soft adder techmap:
- separated wire names for `lut2_out` of different adder stages. These were causing net name conflicts in EBLIF
- tied unused `frac_lut4` inputs to GND